### PR TITLE
Add CMakePresets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 message(STATUS "Building Python language bindings for GPXPy.")
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.23)
 
 project(gpxpy)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,6 @@ message(STATUS "Building Python language bindings for GPXPy.")
 
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
-set(CMAKE_CXX_FLAGS "-O3")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-
 project(gpxpy)
 
 include(CMakeDependentOption)
@@ -39,62 +28,8 @@ if(GPXPY_ENABLE_FORMAT_TARGETS)
 endif()
 
 if(GPXPY_BUILD_CORE)
-  # try finding pybind11
-  set(GPXPy_pybind11_VERSION 2.10.3)
-  find_package(pybind11 ${GPXPy_pybind11_VERSION} QUIET)
-  if(pybind11_FOUND)
-    message(STATUS "Found package pybind11.")
-  else()
-    message(STATUS "Couldn't find package pybind11. Building from source ...")
-    include(FetchContent)
-    set(FETCHCONTENT_QUIET FALSE)
-    # fetch pybind11 library for creating Python bindings
-    FetchContent_Declare(
-      pybind11
-      GIT_REPOSITORY https://github.com/pybind/pybind11.git
-      GIT_TAG "v${GPXPy_pybind11_VERSION}"
-      GIT_SHALLOW TRUE
-      QUIET)
-    FetchContent_MakeAvailable(pybind11)
-    message(STATUS "Installed pybind11 version ${GPXPy_pybind11_VERSION}.")
+  add_subdirectory(core)
+  if(GPXPY_BUILD_BINDINGS)
+    add_subdirectory(bindings)
   endif()
-
-  find_package(HPX REQUIRED)
-  find_package(MKL CONFIG REQUIRED)
-
-  include_directories("${CMAKE_SOURCE_DIR}/core/include")
-  include_directories("${CMAKE_SOURCE_DIR}/bindings")
-  include_directories(${HPX_INCLUDE_DIRS})
-  include_directories(${MKL_INCLUDE_DIRS})
-
-  file(GLOB SOURCE_FILES "core/src/*.cpp")
-  file(GLOB HEADER_FILES "core/include/*.hpp")
-  file(GLOB BINDING_FILES "bindings/*.cpp")
-
-  source_group("Source Files" FILES ${SOURCE_FILES})
-  source_group("Header Files" FILES ${HEADER_FILES})
-  source_group("Binding Files" FILES ${BINDING_FILES})
-
-  pybind11_add_module(gpxpy ${SOURCE_FILES} ${HEADER_FILES} ${BINDING_FILES})
-
-  # Calculate the parent directory of CMAKE_BINARY_DIR
-  get_filename_component(PARENT_BINARY_DIR "${CMAKE_BINARY_DIR}" DIRECTORY)
-
-  # Set the output directory for the automobile target
-  set_target_properties(
-    gpxpy
-    PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-               "${PARENT_BINARY_DIR}/examples/gpxpy_python/install_python"
-               ARCHIVE_OUTPUT_DIRECTORY
-               "${PARENT_BINARY_DIR}/examples/gpxpy_python/install_python"
-               RUNTIME_OUTPUT_DIRECTORY
-               "${PARENT_BINARY_DIR}/examples/gpxpy_python/install_python")
-
-  target_link_libraries(gpxpy PUBLIC HPX::hpx MKL::mkl_intel_lp64 MKL::mkl_core
-                                     MKL::MKL MKL::mkl_sequential)
-
-  install(
-    TARGETS gpxpy
-    COMPONENT python
-    LIBRARY DESTINATION "${PYTHON_LIBRARY_DIR}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ if(GPXPY_ENABLE_FORMAT_TARGETS)
 endif()
 
 if(GPXPY_BUILD_CORE)
+  set(MKL_INTERFACE_FULL "intel_lp64")
+  set(MKL_THREADING "sequential")
+
+  find_package(HPX REQUIRED)
+  find_package(MKL CONFIG REQUIRED)
+
   add_subdirectory(core)
   if(GPXPY_BUILD_BINDINGS)
     add_subdirectory(bindings)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,13 +22,6 @@
       }
     },
     {
-      "name": "dev-mode",
-      "hidden": true,
-      "cacheVariables": {
-        "GPXPy_DEVELOPER_MODE": "ON"
-      }
-    },
-    {
       "name": "cppcheck",
       "hidden": true,
       "cacheVariables": {
@@ -116,7 +109,7 @@
     },
     {
       "name": "ci-coverage",
-      "inherits": ["coverage-linux", "dev-mode"],
+      "inherits": ["coverage-linux"],
       "cacheVariables": {
         "COVERAGE_HTML_COMMAND": ""
       }
@@ -124,7 +117,7 @@
     {
       "name": "ci-sanitize",
       "binaryDir": "${sourceDir}/build/sanitize",
-      "inherits": ["ci-linux", "dev-mode"],
+      "inherits": ["ci-linux"],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Sanitize",
         "CMAKE_CXX_FLAGS_SANITIZE": "-U_FORTIFY_SOURCE -O2 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-common"
@@ -140,24 +133,53 @@
       "description": "Speed up multi-config generators by generating only one configuration instead of the defaults",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CONFIGURATION_TYPES": "Release"
+        "CMAKE_CONFIGURATION_TYPES": "RelWithDebInfo"
       }
     },
     {
       "name": "ci-macos",
-      "inherits": ["ci-build", "ci-darwin", "dev-mode", "ci-multi-config"]
+      "inherits": ["ci-build", "ci-darwin", "ci-multi-config"]
     },
     {
       "name": "ci-ubuntu",
-      "inherits": ["ci-build", "ci-linux", "dev-mode"]
+      "inherits": ["ci-build", "ci-linux"]
+    },
+    {
+      "name": "ci-windows",
+      "inherits": ["ci-build", "ci-win64", "ci-multi-config"]
     },
     {
       "name": "ci-ubuntu-24.04",
       "inherits": ["ci-ubuntu"]
     },
     {
-      "name": "ci-windows",
-      "inherits": ["ci-build", "ci-win64", "dev-mode", "ci-multi-config"]
+      "name": "dev-linux",
+      "binaryDir": "${sourceDir}/build/dev-linux",
+      "inherits": ["ci-linux"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev-linux",
+      "configurePreset": "dev-linux",
+      "configuration": "Debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "dev-linux",
+      "configurePreset": "dev-linux",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,6 @@
     {
       "name": "dev-mode",
       "hidden": true,
-      "inherits": "cmake-pedantic",
       "cacheVariables": {
         "GPXPy_DEVELOPER_MODE": "ON"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,164 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 22,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "cmake-pedantic",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "uninitialized": true,
+        "unusedCli": true,
+        "systemVars": false
+      },
+      "errors": {
+        "dev": true,
+        "deprecated": true
+      }
+    },
+    {
+      "name": "dev-mode",
+      "hidden": true,
+      "inherits": "cmake-pedantic",
+      "cacheVariables": {
+        "GPXPy_DEVELOPER_MODE": "ON"
+      }
+    },
+    {
+      "name": "cppcheck",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_CPPCHECK": "cppcheck;--inline-suppr"
+      }
+    },
+    {
+      "name": "clang-tidy",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--header-filter=^${sourceDir}/"
+      }
+    },
+    {
+      "name": "ci-std",
+      "description": "This preset makes sure the project actually builds with at least the specified standard",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_STANDARD_REQUIRED": "ON"
+      }
+    },
+    {
+      "name": "flags-gcc-clang",
+      "description": "These flags are supported by both GCC and Clang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen",
+        "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen"
+      }
+    },
+    {
+      "name": "flags-appleclang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fstack-protector-strong -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast"
+      }
+    },
+    {
+      "name": "flags-msvc",
+      "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
+        "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf",
+        "CMAKE_SHARED_LINKER_FLAGS": "/machine:x64 /guard:cf"
+      }
+    },
+    {
+      "name": "ci-linux",
+      "inherits": ["flags-gcc-clang", "ci-std"],
+      "generator": "Unix Makefiles",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ci-darwin",
+      "inherits": ["flags-appleclang", "ci-std"],
+      "generator": "Xcode",
+      "hidden": true
+    },
+    {
+      "name": "ci-win64",
+      "inherits": ["flags-msvc", "ci-std"],
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "hidden": true
+    },
+    {
+      "name": "coverage-linux",
+      "binaryDir": "${sourceDir}/build/coverage",
+      "inherits": "ci-linux",
+      "hidden": true,
+      "cacheVariables": {
+        "ENABLE_COVERAGE": "ON",
+        "CMAKE_BUILD_TYPE": "Coverage",
+        "CMAKE_CXX_FLAGS_COVERAGE": "-Og -g --coverage -fkeep-inline-functions -fkeep-static-functions",
+        "CMAKE_EXE_LINKER_FLAGS_COVERAGE": "--coverage",
+        "CMAKE_SHARED_LINKER_FLAGS_COVERAGE": "--coverage"
+      }
+    },
+    {
+      "name": "ci-coverage",
+      "inherits": ["coverage-linux", "dev-mode"],
+      "cacheVariables": {
+        "COVERAGE_HTML_COMMAND": ""
+      }
+    },
+    {
+      "name": "ci-sanitize",
+      "binaryDir": "${sourceDir}/build/sanitize",
+      "inherits": ["ci-linux", "dev-mode"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Sanitize",
+        "CMAKE_CXX_FLAGS_SANITIZE": "-U_FORTIFY_SOURCE -O2 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-common"
+      }
+    },
+    {
+      "name": "ci-build",
+      "binaryDir": "${sourceDir}/build",
+      "hidden": true
+    },
+    {
+      "name": "ci-multi-config",
+      "description": "Speed up multi-config generators by generating only one configuration instead of the defaults",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CONFIGURATION_TYPES": "Release"
+      }
+    },
+    {
+      "name": "ci-macos",
+      "inherits": ["ci-build", "ci-darwin", "dev-mode", "ci-multi-config"]
+    },
+    {
+      "name": "ci-ubuntu",
+      "inherits": ["ci-build", "ci-linux", "dev-mode"]
+    },
+    {
+      "name": "ci-ubuntu-24.04",
+      "inherits": ["ci-ubuntu"]
+    },
+    {
+      "name": "ci-windows",
+      "inherits": ["ci-build", "ci-win64", "dev-mode", "ci-multi-config"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the source code for the GPXPy library.
 ## Dependencies
 
 GPXPy utilizes two external libraries:
+
 - [HPX](https://hpx-docs.stellar-group.org/latest/html/index.html) for asynchronous task-based parallelization
 - [MKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) for CPU-only BLAS computations
 
@@ -16,7 +17,30 @@ Spack environment configurations and setup scripts for CPU and GPU use are provi
 
 ## How To Compile
 
-GPXPy can be build with or without Python bindings. Respective scripts can be found in this directory.
+GPXPy makes use of [CMake presets][1] to simplify the process of configuring
+the project.
+
+For example, building and testing this project on a Linux machine is as easy as running the following commands:
+
+```sh
+cmake --preset=dev-linux
+cmake --build --preset=dev-linux
+ctest --preset=dev-linux
+```
+
+As a developer, you may create a `CMakeUserPresets.json` file at the root of the project that contains additional
+presets local to your machine.
+
+GPXPy can be build with or without Python bindings.
+The following options can be set to include / exclude parts of the project:
+
+| Option name                 | Description                                    | Default value   |
+|-----------------------------|------------------------------------------------|-----------------|
+| GPXPY_BUILD_CORE            | Enable/Disable building of the core library    | ON              |
+| GPXPY_BUILD_BINDINGS        | Enable/Disable building of the Python bindings | ON              |
+| GPXPY_ENABLE_FORMAT_TARGETS | Enable/disable code formatting helper targets  | ON if top-level |
+
+Respective scripts can be found in this directory.
 
 ## How To Run
 
@@ -71,3 +95,5 @@ We specifically thank the follow contributors:
 ## How To Cite
 
 TBD.
+
+[1]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,31 @@
+# try finding pybind11
+set(GPXPy_pybind11_VERSION 2.10.3)
+find_package(pybind11 ${GPXPy_pybind11_VERSION} QUIET)
+if(pybind11_FOUND)
+  message(STATUS "Found package pybind11.")
+else()
+  message(STATUS "Couldn't find package pybind11. Building from source ...")
+  include(FetchContent)
+  set(FETCHCONTENT_QUIET FALSE)
+  # fetch pybind11 library for creating Python bindings
+  FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG "v${GPXPy_pybind11_VERSION}"
+    GIT_SHALLOW TRUE
+    QUIET)
+  FetchContent_MakeAvailable(pybind11)
+  message(STATUS "Installed pybind11 version ${GPXPy_pybind11_VERSION}.")
+endif()
+
+file(GLOB SOURCE_FILES CONFIGURE_DEPENDS "*.cpp")
+file(GLOB HEADER_FILES CONFIGURE_DEPENDS "*.hpp")
+
+source_group("Source Files" FILES ${SOURCE_FILES})
+source_group("Header Files" FILES ${HEADER_FILES})
+
+pybind11_add_module(gpxpy_bindings ${SOURCE_FILES} ${HEADER_FILES})
+# must match the module name!
+set_target_properties(gpxpy_bindings PROPERTIES OUTPUT_NAME "gpxpy")
+
+target_link_libraries(gpxpy_bindings PUBLIC GPXPy::core HPX::wrap_main)

--- a/compile_gpxpy_cpp.sh
+++ b/compile_gpxpy_cpp.sh
@@ -9,33 +9,23 @@ set -e  # Exit immediately if a command exits with a non-zero status.
 # Load GCC compiler
 module load gcc/13.2.0
 module load cmake
-CC_COMPILER=gcc
-CXX_COMPILER=g++
+export CC=gcc
+export CXX=g++
 # Activate spack environment
 spack env activate gpxpy_cpu_gcc
 # # Load Clang compiler
 # module load clang/17.0.1
-# CC_COMPILER=clang
-# CXX_COMPILER=clang++
+# export CC=clang
+# export CXX=clang++
 # # Activate spack environment
 # spack env activate gpxpy_gpu_clang
-# Set cmake command
-export CMAKE_COMMAND=$(which cmake)
 # Configure APEX
 export APEX_SCREEN_OUTPUT=1
-# Configure MKL
-export MKL_CONFIG='-DMKL_ARCH=intel64 -DMKL_LINK=dynamic -DMKL_INTERFACE_FULL=intel_lp64 -DMKL_THREADING=sequential'
 
 ################################################################################
 # Compile code
 ################################################################################
-rm -rf build_cpp && mkdir build_cpp && cd build_cpp
-# Configure the project
-$CMAKE_COMMAND ../core -DCMAKE_BUILD_TYPE=Release \
-                  -DHPX_WITH_DYNAMIC_HPX_MAIN=ON \
-                  -DCMAKE_C_COMPILER=$(which $CC_COMPILER) \
-		  -DCMAKE_CXX_COMPILER=$(which $CXX_COMPILER) \
-                  ${MKL_CONFIG}
- # Build the project
-make -j all
-make install
+# note: dev defaults to debug builds!
+cmake --preset dev-linux -DGPXPY_BUILD_BINDINGS=OFF
+cmake --build --preset dev-linux
+# ctest --preset dev-linux

--- a/compile_gpxpy_python.sh
+++ b/compile_gpxpy_python.sh
@@ -9,34 +9,24 @@ set -e  # Exit immediately if a command exits with a non-zero status.
 # Load GCC compiler
 module load gcc/13.2.0
 module load cmake
-CC_COMPILER=gcc
-CXX_COMPILER=g++
+export CC=gcc
+export CXX=g++
 # Activate spack environment
 spack env activate gpxpy_cpu_gcc
 # # Load Clang compiler
 # module load clang/17.0.1
-# CC_COMPILER=clang
-# CXX_COMPILER=clang++
+# export CC=clang
+# export CXX=clang++
 # # Activate spack environment
 # spack env activate gpxpy_gpu_clang
-# Set cmake command
-export CMAKE_COMMAND=$(which cmake)
 # Configure APEX
 export APEX_SCREEN_OUTPUT=1
-# Configure MKL
-export MKL_CONFIG='-DMKL_ARCH=intel64 -DMKL_LINK=dynamic -DMKL_INTERFACE_FULL=intel_lp64 -DMKL_THREADING=sequential'
 
 ################################################################################
 # Compile code
 ################################################################################
-rm -rf build_python && mkdir build_python && cd build_python
-# Configure the project
-$CMAKE_COMMAND .. -DCMAKE_BUILD_TYPE=Release \
-                  -DPYTHON_LIBRARY_DIR=$(python3 -c "import site; print(site.getsitepackages()[0])") \
-                  -DPYTHON_EXECUTABLE=$(which python3) \
-                  -DHPX_WITH_DYNAMIC_HPX_MAIN=ON \
-                  -DCMAKE_C_COMPILER=$(which $CC_COMPILER) \
-		  -DCMAKE_CXX_COMPILER=$(which $CXX_COMPILER) \
-                  ${MKL_CONFIG}
- # Build the project
-make -j all
+# note: dev defaults to debug builds!
+cmake --preset dev-linux
+cmake --build --preset dev-linux
+# ctest --preset dev-linux
+

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(HPX REQUIRED)
-find_package(MKL CONFIG REQUIRED)
-
 add_library(
   gpxpy_core STATIC
   src/gp_optimizer.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,65 +1,31 @@
-cmake_minimum_required(VERSION 3.16)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-project(gpxpy VERSION 0.1.0)
-
 find_package(HPX REQUIRED)
 find_package(MKL CONFIG REQUIRED)
 
-# Include dir
-include_directories(${HPX_INCLUDE_DIRS})
-include_directories(${MKL_INCLUDE_DIRS})
+add_library(
+  gpxpy_core STATIC
+  src/gp_optimizer.cpp
+  src/gp_functions.cpp
+  src/gp_algorithms_mkl.cpp
+  src/gpxpy_c.cpp
+  src/adapter_mkl.cpp
+  src/tiled_algorithms_cpu.cpp
+  src/gp_uncertainty.cpp
+  src/utils_c.cpp)
 
-# Source files
-set(SOURCE_FILES
-    src/gp_optimizer.cpp
-    src/gp_functions.cpp
-    src/gp_algorithms_mkl.cpp
-    src/gpxpy_c.cpp
-    src/adapter_mkl.cpp
-    src/tiled_algorithms_cpu.cpp
-    src/gp_uncertainty.cpp
-    src/utils_c.cpp)
+add_library(GPXPy::core ALIAS gpxpy_core)
 
-# Headers (to be installed)
-set(HEADER_FILES
-    include/gp_optimizer.hpp
-    include/gp_functions.hpp
-    include/gp_algorithms_cpu.hpp
-    include/gpxpy_c.hpp
-    include/adapter_mkl.hpp
-    include/tiled_algorithms_cpu.hpp
-    include/gp_uncertainty.hpp
-    include/utils_c.hpp)
-
-# Add library
-add_library(gpxpy SHARED ${SOURCE_FILES})
+# Add them as PRIVATE sources here so they show up in project files Can't use
+# PUBLIC etc., see: https://stackoverflow.com/a/62465051
+file(GLOB_RECURSE header_files CONFIGURE_DEPENDS include/*.hpp)
+target_sources(gpxpy_core PRIVATE ${header_files})
 
 # Link HPX libraries
-target_link_libraries(gpxpy PRIVATE ${HPX_LIBRARIES} MKL::MKL)
+target_link_libraries(
+  gpxpy_core PUBLIC HPX::hpx MKL::mkl_intel_lp64
+                    MKL::mkl_core MKL::MKL MKL::mkl_sequential)
 
 # Include directories
 target_include_directories(
-  gpxpy PRIVATE include/ ${HPX_INCLUDE_DIRS}
-                $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+  gpxpy_core PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/core/include>")
 
-# Set the RPATH to include the MKL library paths
-set_target_properties(gpxpy PROPERTIES INSTALL_RPATH "${MKL_LIBRARIES}"
-                                       BUILD_WITH_INSTALL_RPATH ON)
-
-# Set default installation prefix if not specified by user
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  get_filename_component(PARENT_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
-  set(CMAKE_INSTALL_PREFIX
-      "${PARENT_DIR}/examples/gpxpy_cpp/install_cpp"
-      CACHE PATH "Installation Directory" FORCE)
-endif()
-
-# Install
-install(TARGETS gpxpy DESTINATION lib)
-
-# Create base directory
-install(DIRECTORY include/ DESTINATION include)
+target_compile_features(gpxpy_core PUBLIC cxx_std_17)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,11 +18,13 @@ target_sources(gpxpy_core PRIVATE ${header_files})
 
 # Link HPX libraries
 target_link_libraries(
-  gpxpy_core PUBLIC HPX::hpx MKL::mkl_intel_lp64
-                    MKL::mkl_core MKL::MKL MKL::mkl_sequential)
+  gpxpy_core PUBLIC HPX::hpx MKL::mkl_intel_lp64 MKL::mkl_core MKL::MKL
+                    MKL::mkl_sequential)
 
 # Include directories
 target_include_directories(
   gpxpy_core PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/core/include>")
 
 target_compile_features(gpxpy_core PUBLIC cxx_std_17)
+
+set_property(TARGET gpxpy_core PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/spack-repo/environments/spack_cpu_gcc.yaml
+++ b/spack-repo/environments/spack_cpu_gcc.yaml
@@ -1,7 +1,7 @@
 spack:
   specs:
-  - hpx@1.10.0%gcc@13.2.0 networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
-  - intel-oneapi-mkl@2024.2.1%gcc@13.2.0
+  - hpx@1.10.0%gcc networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
+  - intel-oneapi-mkl@2024.2.1%gcc
   view: true
   concretizer:
     unify: true

--- a/spack-repo/environments/spack_gpu_clang.yaml
+++ b/spack-repo/environments/spack_gpu_clang.yaml
@@ -1,8 +1,8 @@
 spack:
   specs:
-  - hpx@1.10.0%clang@17.0.1 +cuda cuda_arch=80 networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
+  - hpx@1.10.0%clang +cuda cuda_arch=80 networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
   - cuda +allow-unsupported-compilers
-  - intel-oneapi-mkl@2024.2.1%clang@17.0.1
+  - intel-oneapi-mkl@2024.2.1%clang
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
This PR adds CMake presets for common configurations and basic compiler setup.

It also updates the project's README to include a description of the new presets and other user-facing options.

TODO: Test of the build scripts on the cluster is still outstanding.