### PR TITLE
GPU Version of Example Implementations for GPflow and GPyTorch

### DIFF
--- a/examples/gpflow_reference/run_gpflow.sh
+++ b/examples/gpflow_reference/run_gpflow.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# Create Python environment
-python3 -m venv gpflow_env
-# Activate environment
-source gpflow_env/bin/activate
-# Install requirements
-pip3 install gpflow
-#
-python3 execute.py

--- a/examples/gpflow_reference/run_gpflow_cpu.sh
+++ b/examples/gpflow_reference/run_gpflow_cpu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Activate spack environment
+source $HOME/spack/share/spack/setup-env.sh
+spack env activate gpxpy
+
+# Create & Activate python enviroment
+if [ ! -d "gpflow_env" ]; then
+    python3 -m venv gpflow_env
+fi
+source gpflow_env/bin/activate
+
+# install requirements
+if ! python3 -c "import gpflow"; then
+    pip3 install gpflow
+fi
+
+# Execute the python script
+python3 execute.py

--- a/examples/gpflow_reference/run_gpflow_gpu.sh
+++ b/examples/gpflow_reference/run_gpflow_gpu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Activate spack environment
+source $HOME/spack/share/spack/setup-env.sh
+spack env activate gpxpy
+
+# Create & Activate python environment
+if [ ! -d "gpflow_env" ]; then
+    python3 -m venv gpflow_env
+fi
+source gpflow_env/bin/activate
+
+# install gpflow if not already installed
+if ! python3 -c "import gpflow"; then
+    pip3 install gpflow
+fi
+
+export XLA_FLAGS=--xla_gpu_cuda_data_dir=$CUDA_HOME/
+
+# Execute the python script
+python3 execute.py --use-gpu

--- a/examples/gpytorch_reference/run_gpytorch.sh
+++ b/examples/gpytorch_reference/run_gpytorch.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# Create Python environment
-python3 -m venv gpytorch_env
-# Activate environment
-source gpytorch_env/bin/activate
-# Install requirements
-pip3 install gpytorch
-#
-python3 execute.py

--- a/examples/gpytorch_reference/run_gpytorch_cpu.sh
+++ b/examples/gpytorch_reference/run_gpytorch_cpu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Activate spack environment
+source $HOME/spack/share/spack/setup-env.sh
+spack env activate gpxpy
+
+# Create & Activate python enviroment
+if [ ! -d "gpytorch_env" ]; then
+    python3 -m venv gpytorch_env
+fi
+
+# Activate enviroment
+source gpytorch_env/bin/activate
+
+# Install requirements
+if ! python3 -c "import gpytorch"; then
+    pip3 install gpytorch
+fi
+
+# Run the python script
+python3 execute.py

--- a/examples/gpytorch_reference/run_gpytorch_gpu.sh
+++ b/examples/gpytorch_reference/run_gpytorch_gpu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Activate spack environment
+source $HOME/spack/share/spack/setup-env.sh
+spack env activate gpxpy
+
+# Create & Activate python enviroment
+if [ ! -d "gpytorch_env" ]; then
+    python3 -m venv gpytorch_env
+fi
+
+# Activate enviroment
+source gpytorch_env/bin/activate
+
+# Install requirements
+if ! python3 -c "import gpytorch"; then
+    pip3 install gpytorch
+fi
+
+# Run the python script
+python3 execute.py --use-gpu


### PR DESCRIPTION
- Added `_cpu` and `_gpu` versions of `run_`-scripts
  -  `run_`-scripts now source spack, check for available venv and required python packages
- `execute.py` scripts utilize `--use-gpu` argument to differ between CPU or GPU execution
- Side note: Python files were formatted using `black` formatter with the `--line-length 80` option