### PR TITLE
Add CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    permissions:
+      packages: write
+
     steps:
     - uses: actions/checkout@v4
 
@@ -42,6 +45,7 @@ jobs:
     - name: Choose environment
       run: |
         cp spack-repo/environments/spack_cpu_gcc.yaml spack.yaml
+        cat spack-repo/environments/ci_env_settings.yaml.tpl >> spack.yaml
 
     - name: Concretize
       run: spack -e . concretize
@@ -68,3 +72,10 @@ jobs:
         name: binaries-${{ matrix.os }}
         path: |
           prefix/
+
+    # See: https://github.com/spack/setup-spack?tab=readme-ov-file#example-caching-your-own-binaries-for-public-repositories
+    - name: Push packages and update index
+      run: |
+        spack -e . mirror set --push --oci-username ${{ github.actor }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
+        spack -e . buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Test
       working-directory: build
-      run: ctest --output-on-failure --no-tests=error -C RelWithDebInfo -j 2
+      run: ctest --output-on-failure --no-tests=ignore -C RelWithDebInfo -j 2
 
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,10 @@ jobs:
       env:
         CC: gcc-14
         CXX: g++-14
-      run: cmake "--preset=ci-${{ matrix.os }}"
+      shell: spack-bash {0}
+      run: |
+        spack env activate .
+        cmake "--preset=ci-${{ matrix.os }}"
 
     - name: Build
       run: cmake --build build --config RelWithDebInfo -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         color: true       # Force color output (SPACK_COLOR=always)
         path: spack
 
+    - name: Register repository
+      run: spack repo add spack-repo
+
     - name: Choose environment
       run: |
         cp spack-repo/environments/spack_cpu_gcc.yaml spack.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,10 @@ jobs:
         CC: gcc-14
         CXX: g++-14
       shell: spack-bash {0}
+      # TODO: we shouldn't have to set the prefix here!
       run: |
         spack env activate .
-        cmake "--preset=ci-${{ matrix.os }}"
+        cmake "--preset=ci-${{ matrix.os }}" -DCMAKE_INSTALL_PREFIX=prefix
 
     - name: Build
       run: cmake --build build --config RelWithDebInfo -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+    - main
+
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install compilers and static analyzers
+      if: matrix.os == 'ubuntu-24.04'
+      run: >-
+        sudo apt-get install cppcheck -y -q
+
+        sudo update-alternatives --install
+        /usr/bin/clang-tidy clang-tidy
+        /usr/bin/clang-tidy-18 150
+
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-18 150
+
+    - name: Set up Spack
+      uses: spack/setup-spack@v2
+      with:
+        ref: releases/v0.23
+        buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
+        color: true       # Force color output (SPACK_COLOR=always)
+        path: spack
+
+    - name: Choose environment
+      run: |
+        cp spack-repo/environments/spack_cpu_gcc.yaml spack.yaml
+
+    - name: Concretize
+      run: spack -e . concretize
+
+    - name: Install
+      run: spack -e . install --no-check-signature
+
+    - name: Configure
+      run: cmake "--preset=ci-${{ matrix.os }}"
+
+    - name: Build
+      run: cmake --build build --config RelWithDebInfo -j 2
+
+    - name: Install
+      run: cmake --install build --config RelWithDebInfo --prefix prefix
+
+    - name: Test
+      working-directory: build
+      run: ctest --output-on-failure --no-tests=error -C RelWithDebInfo -j 2
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: binaries-${{ matrix.os }}
+        path: |
+          prefix/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       run: spack -e . install --no-check-signature
 
     - name: Configure
+      env:
+        CC: gcc-14
+        CXX: g++-14
       run: cmake "--preset=ci-${{ matrix.os }}"
 
     - name: Build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -142,8 +142,7 @@
     },
     {
       "name": "ci-ubuntu",
-      "inherits": ["ci-build", "ci-linux"],
-      "binaryDir": "${sourceDir}/build/ci-ubuntu"
+      "inherits": ["ci-build", "ci-linux"]
     },
     {
       "name": "ci-windows",
@@ -161,6 +160,15 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
+    },
+    {
+      "name": "release-linux",
+      "binaryDir": "${sourceDir}/build/release-linux",
+      "inherits": ["ci-linux"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -170,14 +178,25 @@
       "configuration": "Debug"
     },
     {
-      "name": "ci-ubuntu",
-      "configurePreset": "ci-ubuntu",
-      "configuration": "Release"
+      "name": "release-linux",
+      "configurePreset": "release-linux",
+      "configuration": "RelWithDebInfo"
     }
   ],
   "testPresets": [
     {
       "name": "dev-linux",
+      "configurePreset": "dev-linux",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    },
+    {
+      "name": "release-linux",
       "configurePreset": "dev-linux",
       "configuration": "Debug",
       "output": {

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -24,7 +24,9 @@ file(GLOB HEADER_FILES CONFIGURE_DEPENDS "*.hpp")
 source_group("Source Files" FILES ${SOURCE_FILES})
 source_group("Header Files" FILES ${HEADER_FILES})
 
-pybind11_add_module(gpxpy ${SOURCE_FILES} ${HEADER_FILES})
+pybind11_add_module(gpxpy_bindings ${SOURCE_FILES} ${HEADER_FILES})
+# must match the Python module name!
+set_target_properties(gpxpy_bindings PROPERTIES OUTPUT_NAME "gpxpy")
 
-install(TARGETS gpxpy DESTINATION "${CMAKE_INSTALL_PREFIX}")
-target_link_libraries(gpxpy PUBLIC GPXPy::core)
+install(TARGETS gpxpy_bindings DESTINATION "${CMAKE_INSTALL_PREFIX}")
+target_link_libraries(gpxpy_bindings PUBLIC GPXPy::core)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -26,11 +26,5 @@ source_group("Header Files" FILES ${HEADER_FILES})
 
 pybind11_add_module(gpxpy ${SOURCE_FILES} ${HEADER_FILES})
 
-# Set the output directory for the automobile target
-set_target_properties(
-  gpxpy
-  PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_INSTALL_PREFIX}
-             ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_INSTALL_PREFIX}
-             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_INSTALL_PREFIX})
-
+install(TARGETS gpxpy DESTINATION "${CMAKE_INSTALL_PREFIX}")
 target_link_libraries(gpxpy PUBLIC GPXPy::core)

--- a/compile_gpxpy.sh
+++ b/compile_gpxpy.sh
@@ -29,9 +29,9 @@ export INSTALL_DIR=$(pwd)/examples/gpxpy_python
 # export BINDINGS=OFF
 # export INSTALL_DIR=$(pwd)/examples/gpxpy_cpp
 
-# Release:	ci-ubuntu
+# Release:	release-linux
 # Debug:	dev-linux
-export PRESET=ci-ubuntu
+export PRESET=release-linux
 
 ################################################################################
 # Compile code

--- a/spack-repo/environments/ci_env_settings.yaml.tpl
+++ b/spack-repo/environments/ci_env_settings.yaml.tpl
@@ -1,0 +1,9 @@
+  config:
+    install_tree:
+      root: /opt/spack
+      padded_length: 128
+
+  mirrors:
+    local-buildcache:
+      url: oci://ghcr.io/timniederhausen/spack-buildcache
+      signed: false

--- a/spack-repo/environments/ci_env_settings.yaml.tpl
+++ b/spack-repo/environments/ci_env_settings.yaml.tpl
@@ -5,5 +5,5 @@
 
   mirrors:
     local-buildcache:
-      url: oci://ghcr.io/timniederhausen/spack-buildcache
+      url: oci://ghcr.io/constracktor/spack-buildcache
       signed: false

--- a/spack-repo/environments/spack_cpu_gcc.yaml
+++ b/spack-repo/environments/spack_cpu_gcc.yaml
@@ -1,7 +1,7 @@
 spack:
   specs:
-  - hpx@1.10.0%gcc@13.2.0 networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
-  - intel-oneapi-mkl@2024.2.1%gcc@13.2.0
+  - hpx@1.10.0%gcc networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
+  - intel-oneapi-mkl@2024.2.1%gcc
   view: true
   concretizer:
     unify: true

--- a/spack-repo/environments/spack_gpu_clang.yaml
+++ b/spack-repo/environments/spack_gpu_clang.yaml
@@ -1,8 +1,8 @@
 spack:
   specs:
-  - hpx@1.10.0%clang@17.0.1 +cuda cuda_arch=80 networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
+  - hpx@1.10.0%clang +cuda cuda_arch=80 networking=none max_cpu_count=256 instrumentation=apex ^cmake@3.30 ^curl@8.10.1 ^ninja@1.12.1
   - cuda +allow-unsupported-compilers
-  - intel-oneapi-mkl@2024.2.1%clang@17.0.1
+  - intel-oneapi-mkl@2024.2.1%clang
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
This adds a GitHub Actions-based CI pipeline that builds the project on Linux (x86-64 for now) and runs its registered tests.

A `.zip` archive of the built binaries is provided as an artifact.