### PR TITLE
Fixed prediction of variance vector

### DIFF
--- a/core/src/gp_functions.cpp
+++ b/core/src/gp_functions.cpp
@@ -293,12 +293,6 @@ predict_with_uncertainty_hpx(const std::vector<double> &training_input,
     }
     // Assemble placeholder for uncertainty
     prediction_uncertainty_tiles.resize(m_tiles);
-    for (std::size_t i = 0; i < m_tiles; i++)
-    {
-        prediction_uncertainty_tiles[i] = hpx::async(
-            hpx::annotated_function(&gen_tile_zeros, "assemble_tiled"),
-            m_tile_size);
-    }
 
     //////////////////////////////////////////////////////////////////////////////
     //// Compute Cholesky decomposition

--- a/core/src/gp_uncertainty.cpp
+++ b/core/src/gp_uncertainty.cpp
@@ -16,7 +16,9 @@ std::vector<double> diag_posterior(const std::vector<double> &A,
                                    const std::vector<double> &B,
                                    std::size_t M)
 {
-    std::vector<double> tile(M);
+    // Initialize tile
+    std::vector<double> tile;
+    tile.reserve(M);
 
     for (std::size_t i = 0; i < M; ++i)
     {


### PR DESCRIPTION
- Previously, the returned variance vector was twice the size with the first half being zeros. Now, the vector has the same size as the vector of the predicted values, without the zeros.
- Allocate memory with reserve instead of constructor
  - Constructor auto-fills elements with 0
  - Reserve just allocates the memory for upcoming push_back calls
- Also removed unnecessary initialization of vector in predict_with_uncertainty because the vector is overridden in subsequent function call